### PR TITLE
Improve Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,11 @@ RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
 ENV PATH="${PATH}:${POETRY_HOME}/bin"
 
 WORKDIR /app
-COPY pyproject.toml seodpconfig.yaml .env ./
+COPY pyproject.toml ./
 
 RUN poetry install --only=main --no-interaction --no-ansi
 
-COPY . ./
+COPY ./src ./src
 
-CMD ["poetry", "run", "python", "src/seodp/main.py"]
+ENTRYPOINT ["poetry", "run", "python", "src/seodp/main.py"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM python:3.9-slim
 
+ENV PYTHONUNBUFFERED=1 POETRY_HOME="/opt/poetry" POETRY_VIRTUALENVS_IN_PROJECT=true
+RUN apt-get update && apt-get install -y build-essential curl software-properties-common git
+RUN rm -rf /var/lib/apt/lists/*
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
+ENV PATH="${PATH}:${POETRY_HOME}/bin"
+
 WORKDIR /app
+COPY pyproject.toml seodpconfig.yaml .env ./
 
-COPY pyproject.toml .
-COPY .env .
-COPY seodpconfig.yaml .
+RUN poetry install --only=main --no-interaction --no-ansi
 
-RUN pip install poetry
-RUN poetry config virtualenvs.create false
-RUN poetry install --no-dev
+COPY . ./
 
-COPY . .
-
-CMD ["python", "src/seodp/main.py"]
+CMD ["poetry", "run", "python", "src/seodp/main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
-version: '3'
+name: seodp
 services:
   seodp:
-    build: .
+    container_name: seodp
+    env_file:
+      - ./.env
     volumes:
-      - .:/app
-      - ./.env:/app/.env
-      - ./seodpconfig.yaml:/app/seodpconfig.yaml
-    environment:
-      - SCHEDULE=${SCHEDULE:-monthly}
-    command: python src/seodp/main.py --start
+      - "./service-account.json:/app/service-account.json"
+      - "./seodpconfig.yaml:/app/seodpconfig.yaml"
+    image: seodp
+    command: --start
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - "./service-account.json:/app/service-account.json"
       - "./seodpconfig.yaml:/app/seodpconfig.yaml"
+      - "./seodp.db:/app/seodp.db"
     image: seodp
     command: --start
     restart: unless-stopped


### PR DESCRIPTION
I made the following updates to the Dockerfile:

- Make sure general useful software stuff is installed (I saw this on StackOverflow somewhere)
- Install poetry with the proper installer and fix version
- Use in-project venv
- Avoid copying secrets into the image
- Make the running command customizable (start/sitemap_test/etc) - default to help

I made the following updates to the docker-compose file:

- Give it a name to reuse container
- Pass secrets into run environment from env file
- Load service account in as volume
- Load config in as volume, so you don't have to rebuild the image to change it
- Load DB in as volume so it persists
- Restart automatically
- Default to --start command when run this way

Users must change the service account name in docker-compose if they want to run it.

Build with `docker build -t seodp .`.

You can now run the thing with `docker-compose up -d` (`-d` is run in background) for the regular scheduler. For other commands, you can edit the compose file or you can run them in Docker with a command like this:

```zsh
docker run --env-file ./.env -v $(pwd)/locomotive-reporting.json:/app/locomotive-reporting.json -v $(pwd)/seodpconfig.yaml:/app/seodpconfig.yaml -v $(pwd)/seodp.db:/app/seodp.db --name seodp seodp --sitemap_test
```

Which is essentially doing the same thing as in the docker-compose.